### PR TITLE
feat: 회원 가입 - 이메일, 비밀번호 입력 UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "14.1.3",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.51.4",
     "recoil": "^0.7.7",
     "tailwind-merge": "^2.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   react-dom:
     specifier: ^18
     version: 18.2.0(react@18.2.0)
+  react-hook-form:
+    specifier: ^7.51.4
+    version: 7.51.4(react@18.2.0)
   recoil:
     specifier: ^0.7.7
     version: 0.7.7(react-dom@18.2.0)(react@18.2.0)
@@ -2689,6 +2692,15 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-hook-form@7.51.4(react@18.2.0):
+    resolution: {integrity: sha512-V14i8SEkh+V1gs6YtD0hdHYnoL4tp/HX/A45wWQN15CYr9bFRmmRdYStSO5L65lCCZRF+kYiSKhm9alqbcdiVA==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /react-is@16.13.1:

--- a/src/app/(route)/signup/page.tsx
+++ b/src/app/(route)/signup/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import Button from "@/app/_components/Button";
+import { INPUT_IDs, Input, InputLabel } from "@/app/_components/Input";
+import { Strings } from "@/app/_resource/constants";
+import { useState } from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
+import { twMerge } from "tailwind-merge";
+
+type FormFields = {
+  email: string;
+  emailValidation: string;
+  password: string;
+  passwordConfirm: string;
+};
+
+export default function SignUpPage() {
+  const [showEmailValidation, setShowEmailValidation] =
+    useState<boolean>(false);
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors },
+    getValues,
+  } = useForm<FormFields>();
+
+  const onClickSendEmailValidation = (event: React.MouseEvent<HTMLElement>) => {
+    event?.preventDefault(); // onSubmit 방지
+
+    try {
+      // todo: 이메일 인증 번호 발송
+      if (validateEmail(getValues(INPUT_IDs.email)) == true) {
+        setShowEmailValidation(true);
+      }
+    } catch (error) {
+      //
+    }
+  };
+
+  const onSubmit: SubmitHandler<FormFields> = async (data) => {
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      console.log(data);
+    } catch (error) {
+      setError(INPUT_IDs.email, {
+        message: "이미 존재하는 이메일입니다.", // todo: 에러 처리
+      });
+    }
+  };
+
+  const validateEmail = (value: string): boolean | string => {
+    const regex_email = /^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$/;
+
+    if (!regex_email.test(value)) {
+      return "정확한 이메일을 입력해주세요";
+    }
+    return true;
+  };
+
+  const validatePassword = (value: string): boolean | string => {
+    const regex_eng_num_10 = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{10,}$/;
+    const regex_eng_num_special_8 =
+      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/;
+
+    if (!regex_eng_num_10.test(value) && !regex_eng_num_special_8.test(value)) {
+      return "영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상이어야 합니다.";
+    }
+    return true;
+  };
+
+  return (
+    <div
+      className={twMerge(
+        "flex flex-col justify-center items-center",
+        "p-[40px]" // todo: 위치 조정
+      )}
+    >
+      <div
+        className={twMerge("mb-[30px] font-semibold text-[33px] text-black")}
+      >
+        {Strings.SIGN_UP_TITLE}
+      </div>
+
+      <div className={twMerge("mb-[30px] text-[18px] text-slate-400")}>
+        {Strings.SIGN_UP_DESC}
+      </div>
+
+      {/* Form */}
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className={twMerge(
+          "flex flex-col w-[442px]" // todo: 442px to const
+        )}
+      >
+        {/* email */}
+        <div className={twMerge("flex flex-col mb-[20px] space-y-[8px]")}>
+          <InputLabel id={INPUT_IDs.email} label={Strings.SIGN_UP_EMAIL} />
+          <Input
+            id={INPUT_IDs.email}
+            placeholder={Strings.SIGN_UP_EMAIL_PLACEHOLDER}
+            {...register(INPUT_IDs.email, {
+              required: "이메일을 입력해주세요",
+              validate: validateEmail,
+            })}
+          />
+          {errors.email && (
+            <div className={twMerge("font-medium text-[14px] text-red_EF4444")}>
+              {errors.email.message}
+            </div>
+          )}
+          {/* 이메일 인증하기 버튼 */}
+          <Button
+            className={twMerge("w-full h-[40px] font-medium text-[14px]")}
+            variant={"primary_outlined"}
+            onClick={onClickSendEmailValidation}
+          >
+            {showEmailValidation ? "인증 번호 재발송" : "인증 번호 발송"}
+          </Button>
+
+          {/* 이메일 인증 번호 */}
+          {showEmailValidation && (
+            <>
+              <InputLabel id={INPUT_IDs.emailValidation} label={"인증번호"} />
+              <Input
+                id={INPUT_IDs.emailValidation}
+                placeholder={"인증번호"}
+                {...register(INPUT_IDs.emailValidation, {
+                  required: "이메일로 발송된 인증번호를 입력해주세요.",
+                  validate: (value) => {
+                    // todo: 이메일 인증 번호 체크
+                    return true;
+                  },
+                })}
+              />
+              {errors.emailValidation && (
+                <div
+                  className={twMerge("font-medium text-[14px] text-red_EF4444")}
+                >
+                  {errors.emailValidation.message}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* 비밀번호 */}
+        <div className={twMerge("flex flex-col mb-[15px] space-y-[8px]")}>
+          <InputLabel
+            id={INPUT_IDs.password}
+            label={Strings.SIGN_UP_PASSWORD}
+          />
+          <div className={twMerge("text-[14px] text-slate-500")}>
+            {Strings.SIGN_UP_PASSWORD_CONDITION}
+          </div>
+          <Input
+            id={INPUT_IDs.password}
+            type={"password"}
+            placeholder={Strings.SIGN_UP_PASSWORD_PLACEHOLDER}
+            {...register(INPUT_IDs.password, {
+              required: "비밀번호를 입력해주세요.",
+              validate: validatePassword,
+            })}
+          />
+          {errors.password && (
+            <div className={twMerge("font-medium text-[14px] text-red_EF4444")}>
+              {errors.password.message}
+            </div>
+          )}
+
+          <Input
+            type={"password"}
+            placeholder={Strings.SIGN_UP_PASSWORD_CONFIRM_PLACEHOLDER}
+            {...register(INPUT_IDs.passwordConfirm, {
+              required: "비밀번호를 한 번 더 입력해주세요.",
+              validate: (value) => {
+                if (value != getValues(INPUT_IDs.password)) {
+                  return "동일한 비밀번호를 입력해주세요.";
+                }
+                return true;
+              },
+            })}
+          />
+          {errors.passwordConfirm && (
+            <div className={twMerge("font-medium text-[14px] text-red_EF4444")}>
+              {errors.passwordConfirm.message}
+            </div>
+          )}
+        </div>
+
+        {/* 다음 버튼 */}
+        <Button className={twMerge("w-full h-[40px] font-medium text-[14px]")}>
+          {Strings.NEXT}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(route)/signup/page.tsx
+++ b/src/app/(route)/signup/page.tsx
@@ -45,27 +45,27 @@ export default function SignUpPage() {
       console.log(data);
     } catch (error) {
       setError(INPUT_IDs.email, {
-        message: "이미 존재하는 이메일입니다.", // todo: 에러 처리
+        message: Strings.SIGN_UP_ERROR_EMAIL_ALREADY_EXISTS, // todo: 에러 처리
       });
     }
   };
 
   const validateEmail = (value: string): boolean | string => {
-    const regex_email = /^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$/;
+    const REGEX_EMAIL = /^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+.[a-zA-Z0-9-.]+$/;
 
-    if (!regex_email.test(value)) {
-      return "정확한 이메일을 입력해주세요";
+    if (!REGEX_EMAIL.test(value)) {
+      return Strings.SIGN_UP_ERROR_INVALID_EMAIL;
     }
     return true;
   };
 
   const validatePassword = (value: string): boolean | string => {
-    const regex_eng_num_10 = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{10,}$/;
-    const regex_eng_num_special_8 =
+    const REGEX_ENG_NUM_10 = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{10,}$/;
+    const REGEX_ENG_NUM_SPECIAL_8 =
       /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/;
 
-    if (!regex_eng_num_10.test(value) && !regex_eng_num_special_8.test(value)) {
-      return "영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상이어야 합니다.";
+    if (!REGEX_ENG_NUM_10.test(value) && !REGEX_ENG_NUM_SPECIAL_8.test(value)) {
+      return Strings.SIGN_UP_ERROR_INVALID_PASSWORD_CONDITION;
     }
     return true;
   };
@@ -77,57 +77,59 @@ export default function SignUpPage() {
         "p-[40px]" // todo: 위치 조정
       )}
     >
-      <div
-        className={twMerge("mb-[30px] font-semibold text-[33px] text-black")}
-      >
+      <div className={"mb-[30px] font-semibold text-[33px] text-black"}>
         {Strings.SIGN_UP_TITLE}
       </div>
 
-      <div className={twMerge("mb-[30px] text-[18px] text-slate-400")}>
+      <div className={"mb-[30px] text-[18px] text-slate-400"}>
         {Strings.SIGN_UP_DESC}
       </div>
 
       {/* Form */}
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className={twMerge(
-          "flex flex-col w-[442px]" // todo: 442px to const
-        )}
+        className={"flex flex-col w-[442px]"}
       >
         {/* email */}
-        <div className={twMerge("flex flex-col mb-[20px] space-y-[8px]")}>
+        <div className={"flex flex-col mb-[20px] space-y-[8px]"}>
           <InputLabel id={INPUT_IDs.email} label={Strings.SIGN_UP_EMAIL} />
           <Input
             id={INPUT_IDs.email}
             placeholder={Strings.SIGN_UP_EMAIL_PLACEHOLDER}
             {...register(INPUT_IDs.email, {
-              required: "이메일을 입력해주세요",
+              required: Strings.SIGN_UP_ERROR_EMAIL_REQUIRED,
               validate: validateEmail,
             })}
           />
           {errors.email && (
-            <div className={twMerge("font-medium text-[14px] text-red_EF4444")}>
+            <div className={"font-medium text-[14px] text-red_EF4444"}>
               {errors.email.message}
             </div>
           )}
           {/* 이메일 인증하기 버튼 */}
           <Button
-            className={twMerge("w-full h-[40px] font-medium text-[14px]")}
+            className={"w-full h-[40px] font-medium text-[14px]"}
             variant={"primary_outlined"}
             onClick={onClickSendEmailValidation}
           >
-            {showEmailValidation ? "인증 번호 재발송" : "인증 번호 발송"}
+            {showEmailValidation
+              ? Strings.SIGN_UP_RESEND_EMAIL_VALIDATION_CODE
+              : Strings.SIGN_UP_SEND_EMAIL_VALIDATION_CODE}
           </Button>
 
           {/* 이메일 인증 번호 */}
           {showEmailValidation && (
             <>
-              <InputLabel id={INPUT_IDs.emailValidation} label={"인증번호"} />
+              <InputLabel
+                id={INPUT_IDs.emailValidation}
+                label={Strings.SIGN_UP_EMAIL_VALIDATION_CODE}
+              />
               <Input
                 id={INPUT_IDs.emailValidation}
-                placeholder={"인증번호"}
+                placeholder={Strings.SIGN_UP_EMAIL_VALIDATION_CODE}
                 {...register(INPUT_IDs.emailValidation, {
-                  required: "이메일로 발송된 인증번호를 입력해주세요.",
+                  required:
+                    Strings.SIGN_UP_ERROR_ENTER_VALIDATION_CODE_IN_EMAIL,
                   validate: (value) => {
                     // todo: 이메일 인증 번호 체크
                     return true;
@@ -135,9 +137,7 @@ export default function SignUpPage() {
                 })}
               />
               {errors.emailValidation && (
-                <div
-                  className={twMerge("font-medium text-[14px] text-red_EF4444")}
-                >
+                <div className={"font-medium text-[14px] text-red_EF4444"}>
                   {errors.emailValidation.message}
                 </div>
               )}
@@ -146,12 +146,12 @@ export default function SignUpPage() {
         </div>
 
         {/* 비밀번호 */}
-        <div className={twMerge("flex flex-col mb-[15px] space-y-[8px]")}>
+        <div className={"flex flex-col mb-[15px] space-y-[8px]"}>
           <InputLabel
             id={INPUT_IDs.password}
             label={Strings.SIGN_UP_PASSWORD}
           />
-          <div className={twMerge("text-[14px] text-slate-500")}>
+          <div className={"text-[14px] text-slate-500"}>
             {Strings.SIGN_UP_PASSWORD_CONDITION}
           </div>
           <Input
@@ -159,12 +159,12 @@ export default function SignUpPage() {
             type={"password"}
             placeholder={Strings.SIGN_UP_PASSWORD_PLACEHOLDER}
             {...register(INPUT_IDs.password, {
-              required: "비밀번호를 입력해주세요.",
+              required: Strings.SIGN_UP_ERROR_PASSWORD_REQUIRED,
               validate: validatePassword,
             })}
           />
           {errors.password && (
-            <div className={twMerge("font-medium text-[14px] text-red_EF4444")}>
+            <div className={"font-medium text-[14px] text-red_EF4444"}>
               {errors.password.message}
             </div>
           )}
@@ -173,24 +173,24 @@ export default function SignUpPage() {
             type={"password"}
             placeholder={Strings.SIGN_UP_PASSWORD_CONFIRM_PLACEHOLDER}
             {...register(INPUT_IDs.passwordConfirm, {
-              required: "비밀번호를 한 번 더 입력해주세요.",
+              required: Strings.SIGN_UP_ERROR_REENTER_PASSWORD,
               validate: (value) => {
                 if (value != getValues(INPUT_IDs.password)) {
-                  return "동일한 비밀번호를 입력해주세요.";
+                  return Strings.SIGN_UP_ERROR_ENTER_SAME_PASSWORD;
                 }
                 return true;
               },
             })}
           />
           {errors.passwordConfirm && (
-            <div className={twMerge("font-medium text-[14px] text-red_EF4444")}>
+            <div className={"font-medium text-[14px] text-red_EF4444"}>
               {errors.passwordConfirm.message}
             </div>
           )}
         </div>
 
         {/* 다음 버튼 */}
-        <Button className={twMerge("w-full h-[40px] font-medium text-[14px]")}>
+        <Button className={"w-full h-[40px] font-medium text-[14px]"}>
           {Strings.NEXT}
         </Button>
       </form>

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -7,7 +7,9 @@ const VARIANTS = {
     "bg-white border-[1px] border-green_2BAE66 text-green_2BAE66 hover:border-green_209957 hover:text-green_209957",
   red_filled: "bg-red_EF4444 hover:bg-red_DC2626 text-white",
   ghost: "bg-transparent text-green_2BAE66 hover:bg-opacity-50",
-  disabled: "bg-slate-500 text-white cursor-default",
+  disabled_filled: "bg-slate-500 text-white cursor-default",
+  disabled_outlined:
+    "bg-white border-[1px] border-slate-300 text-slate-300 cursor-default",
 };
 
 type IButtonProps = {

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -7,10 +7,11 @@ const VARIANTS = {
     "bg-white border-[1px] border-green_2BAE66 text-green_2BAE66 hover:border-green_209957 hover:text-green_209957",
   red_filled: "bg-red_EF4444 hover:bg-red_DC2626 text-white",
   ghost: "bg-transparent text-green_2BAE66 hover:bg-opacity-50",
+  disabled: "bg-slate-500 text-white cursor-default",
 };
 
 type IButtonProps = {
-  variant?: "primary_filled" | "primary_outlined" | "red_filled" | "ghost";
+  variant?: keyof typeof VARIANTS;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 export default function Button({
@@ -28,7 +29,8 @@ export default function Button({
         variant && VARIANTS[variant],
         className && className
       )}
-      onClick={onClick}>
+      onClick={onClick}
+    >
       {children && children}
     </button>
   );

--- a/src/app/_components/Input.tsx
+++ b/src/app/_components/Input.tsx
@@ -29,8 +29,8 @@ export const Input = forwardRef<HTMLInputElement, IInputProps>(
         ref={forwardedRef}
         id={props.id}
         className={twMerge(
+          "flex-1",
           "px-[12px] py-[8px]",
-          "w-[450px] h-[40px]",
           "rounded-md border-[1px] border-gray_E5E5E5",
           "text-[16px]",
           "focus:outline-none focus:border-green_1D7846 focus:ring-green_1D7846 focus:ring-1",

--- a/src/app/_components/Input.tsx
+++ b/src/app/_components/Input.tsx
@@ -1,25 +1,46 @@
-import { InputHTMLAttributes } from "react";
+import { InputHTMLAttributes, forwardRef } from "react";
 import { twMerge } from "tailwind-merge";
 
-type IInputProps = {
-  placeholder?: string;
-} & InputHTMLAttributes<HTMLInputElement>;
+export const INPUT_IDs = {
+  email: "email",
+  emailValidation: "emailValidation",
+  password: "password",
+  passwordConfirm: "passwordConfirm",
+} as const;
 
-export default function Input({
-  children,
-  className,
-  onChange,
-  placeholder,
-}: IInputProps) {
+export type INPUT_IDs = (typeof INPUT_IDs)[keyof typeof INPUT_IDs];
+
+export function InputLabel(props: { id: INPUT_IDs; label: string }) {
   return (
-    <input
-      className={twMerge(
-        "border px-[12px] py-[8px] border-gray_E5E5E5 rounded-md w-[450px] h-[40px] focus:outline-none focus:border-green_1D7846 focus:ring-green_1D7846 focus:ring-1  hover:border-green_2BAE66 placeholder:text-gray_999999",
-        className && className
-      )}
-      placeholder={placeholder}
-      onChange={onChange}>
-      {children && children}
-    </input>
+    <label
+      htmlFor={props.id}
+      className={twMerge("font-medium text-[14px] text-black")}
+    >
+      {props.label}
+    </label>
   );
 }
+
+interface IInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  id?: INPUT_IDs;
+}
+
+export const Input = forwardRef<HTMLInputElement, IInputProps>(
+  function Input(props, forwardedRef) {
+    return (
+      <input
+        ref={forwardedRef}
+        id={props.id}
+        className={twMerge(
+          "px-[12px] py-[8px]",
+          "w-[450px] h-[40px]",
+          "rounded-md border-[1px] border-gray_E5E5E5",
+          "text-[16px]",
+          "focus:outline-none focus:border-green_1D7846 focus:ring-green_1D7846 focus:ring-1",
+          "hover:border-green_2BAE66 placeholder:text-gray_999999"
+        )}
+        {...props}
+      />
+    );
+  }
+);

--- a/src/app/_components/Input.tsx
+++ b/src/app/_components/Input.tsx
@@ -12,10 +12,7 @@ export type INPUT_IDs = (typeof INPUT_IDs)[keyof typeof INPUT_IDs];
 
 export function InputLabel(props: { id: INPUT_IDs; label: string }) {
   return (
-    <label
-      htmlFor={props.id}
-      className={twMerge("font-medium text-[14px] text-black")}
-    >
+    <label htmlFor={props.id} className={"font-medium text-[14px] text-black"}>
       {props.label}
     </label>
   );

--- a/src/app/_resource/constants.ts
+++ b/src/app/_resource/constants.ts
@@ -11,7 +11,8 @@ export const Strings = {
   SIGN_UP_EMAIL_VALIDATION_CODE: "인증번호",
   SIGN_UP_SEND_EMAIL_VALIDATION_CODE: "인증 번호 발송",
   SIGN_UP_RESEND_EMAIL_VALIDATION_CODE: "인증 번호 재발송",
-  SIGN_UP_ERROR_INVALID_EMAIL: "정확한 이메일을 입력해주세요.",
+  SIGN_UP_EMAIL_VALIDATION: "인증",
+  SIGN_UP_ERROR_INVALID_EMAIL: "유효한 이메일 주소를 입력해주세요.",
   SIGN_UP_ERROR_INVALID_PASSWORD_CONDITION:
     "영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상이어야 합니다.",
   SIGN_UP_ERROR_ENTER_VALIDATION_CODE_IN_EMAIL:
@@ -21,5 +22,5 @@ export const Strings = {
   SIGN_UP_ERROR_REENTER_PASSWORD: "비밀번호를 재입력해주세요.",
   SIGN_UP_ERROR_ENTER_SAME_PASSWORD: "동일한 비밀번호를 입력해주세요.",
   SIGN_UP_ERROR_EMAIL_ALREADY_EXISTS: "이미 존재하는 이메일입니다.",
-  NEXT: "다음",
+  SIGN_UP_DONE: "회원가입하기",
 };

--- a/src/app/_resource/constants.ts
+++ b/src/app/_resource/constants.ts
@@ -8,5 +8,18 @@ export const Strings = {
     "영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상",
   SIGN_UP_PASSWORD_PLACEHOLDER: "비밀번호 입력",
   SIGN_UP_PASSWORD_CONFIRM_PLACEHOLDER: "비밀번호 재입력",
+  SIGN_UP_EMAIL_VALIDATION_CODE: "인증번호",
+  SIGN_UP_SEND_EMAIL_VALIDATION_CODE: "인증 번호 발송",
+  SIGN_UP_RESEND_EMAIL_VALIDATION_CODE: "인증 번호 재발송",
+  SIGN_UP_ERROR_INVALID_EMAIL: "정확한 이메일을 입력해주세요.",
+  SIGN_UP_ERROR_INVALID_PASSWORD_CONDITION:
+    "영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상이어야 합니다.",
+  SIGN_UP_ERROR_ENTER_VALIDATION_CODE_IN_EMAIL:
+    "이메일로 발송된 인증번호를 입력해주세요.",
+  SIGN_UP_ERROR_EMAIL_REQUIRED: "이메일을 입력해주세요",
+  SIGN_UP_ERROR_PASSWORD_REQUIRED: "비밀번호를 입력해주세요.",
+  SIGN_UP_ERROR_REENTER_PASSWORD: "비밀번호를 재입력해주세요.",
+  SIGN_UP_ERROR_ENTER_SAME_PASSWORD: "동일한 비밀번호를 입력해주세요.",
+  SIGN_UP_ERROR_EMAIL_ALREADY_EXISTS: "이미 존재하는 이메일입니다.",
   NEXT: "다음",
 };

--- a/src/app/_resource/constants.ts
+++ b/src/app/_resource/constants.ts
@@ -1,0 +1,12 @@
+export const Strings = {
+  SIGN_UP_TITLE: "회원가입 하기",
+  SIGN_UP_DESC: "이리온에서 귀여운 멍냥이들을 만나요!",
+  SIGN_UP_EMAIL: "이메일",
+  SIGN_UP_EMAIL_PLACEHOLDER: "Email@example.com",
+  SIGN_UP_PASSWORD: "비밀번호",
+  SIGN_UP_PASSWORD_CONDITION:
+    "영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상",
+  SIGN_UP_PASSWORD_PLACEHOLDER: "비밀번호 입력",
+  SIGN_UP_PASSWORD_CONFIRM_PLACEHOLDER: "비밀번호 재입력",
+  NEXT: "다음",
+};


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feat/signup

### 💡 작업동기
- 회원가입 화면 작업

### 🔑 주요 변경사항
- Input, InputLabel 컴포넌트 추가
- react-hook-form 라이브러리 추가
- signup 페이지
  - 회원가입 - 이메일, 이메일 인증, 비밀번호 입력 UI

### 🙉 리뷰어에게 전달하고픈 정보
- 이메일 인증 관련해 UI/UX 확인 중입니다.
- 회원가입에서 닉네임/프로필 사진 설정을 제외해 회원가입 단계를 줄이는 게 좋을 것 같습니다.
  - 마이페이지에서 설정할 수 있어, 회원가입시에는 디폴트 프로필 사진 & 랜덤 생성 닉네임으로 하면 어떨까요?

### 🏞 스크린샷
* 수정후
![image](https://github.com/UhPoo/ireon-fe/assets/150026803/df0f40ee-c591-4be4-a406-456b08dddb23)

* 수정전
![image](https://github.com/UhPoo/ireon-fe/assets/150026803/c02be9b9-264f-4513-be1a-31db26856826)


